### PR TITLE
actor logsの有効化とcheckpoint rewardの修正

### DIFF
--- a/common/actor.py
+++ b/common/actor.py
@@ -165,14 +165,12 @@ def actor_loop(create_env_fn):
             # temporaly disabled this due to GPU memory error: https://github.com/tensorflow/tensorboard/issues/2485
             # to tensorboard @kuto
             # we should probably assert env.
-            #if hasattr(env, 'difficulty'):
-            #  tf.summary.scalar('actor/difficulty', env.difficulty)
+            if hasattr(env, 'difficulty'):
+             tf.summary.scalar('actor/difficulty', env.difficulty)
             # TODO: Should probably make checkpoint reward as FLAG
-            #if hasattr(env, 'checkpoint_reward'):
-            #  tf.summary.scalar('actor/checkpoint', env.checkpoint_reward)
-            #tf.summary.scalar('actor/reward', episode_return_sum)
-            #tf.summary.scalar('actor/raw_reward', episode_raw_return_sum)
-            #summary_writer.flush()
+            if hasattr(env, 'checkpoint_reward'):
+             tf.summary.scalar('actor/checkpoint reward', env.checkpoint_reward)
+            summary_writer.flush()
 
             # Finally, we reset the episode which will report the transition
             # from the terminal state to the resetted state in the next loop

--- a/football/vtrace_adaptive_main.py
+++ b/football/vtrace_adaptive_main.py
@@ -40,8 +40,9 @@ flags.DEFINE_bool('adaptive_learning', True,
                   'Whether adjust difficulty as training goes.')
 flags.DEFINE_float('initial_difficulty', 1.0, 'initial difficulty')
 
-flags.DEFINE_bool('custom_checkpoints', False,
+flags.DEFINE_bool('custom_checkpoints', True,
                   'Whether custom checkpoints rewward is enabled.')
+flags.DEFINE_integer('checkpoint_num_episodes', 160000, 'number of episodes which checkpoint reward need to reach zero(NOT number of steps)')  # 160000epi=480Msteps
 
 # https://sites.google.com/view/rl-football/singleagent-team
 class DifficultyWrapper(gym.Wrapper):
@@ -100,16 +101,23 @@ class DifficultyWrapper(gym.Wrapper):
 class CustomCheckpointRewardWrapper(gym.RewardWrapper):
   """A wrapper that adds a dense checkpoint reward."""
 
-  def __init__(self, env):
+  def __init__(self, env, checkpoint_num_episodes):
     gym.RewardWrapper.__init__(self, env)
     self._collected_checkpoints = {}
     self._num_checkpoints = 10
     self.checkpoint_reward = 0.1
-    self.epsilon = 0.99998  # exponential
+    # self.epsilon = 0.99998  # exponential
+    self.epsilon = self.checkpoint_reward / checkpoint_num_episodes # linear
 
   def reset(self):
     self._collected_checkpoints = {}
-    self.checkpoint_reward = np.float32(self.checkpoint_reward * self.epsilon)
+    # self.checkpoint_reward = np.float32(self.checkpoint_reward * self.epsilon)  # exponential
+    if self.checkpoint_reward > 0.0:
+      prev_checkpoint_reward = self.checkpoint_reward
+      self.checkpoint_reward = np.around(np.float32(self.checkpoint_reward - self.epsilon), decimals=8) # linear
+      print(f"[Reset] Checkpoint reward from {prev_checkpoint_reward} to {self.checkpoint_reward}", file=sys.stderr)
+    else:
+      self.checkpoint_reward = 0.0
     return self.env.reset()
 
   def get_state(self, to_pickle):
@@ -182,7 +190,7 @@ def create_environment(_unused):
     e = DifficultyWrapper(e, FLAGS.initial_difficulty)
   if FLAGS.custom_checkpoints:
     print("**** Custom checkpoints reward enabled ****", file=sys.stderr)
-    e = CustomCheckpointRewardWrapper(e)  # add @kuto
+    e = CustomCheckpointRewardWrapper(e, FLAGS.checkpoint_num_episodes)  # add @kuto
   return e
 
 def main(argv):


### PR DESCRIPTION
actor logsの有効化
checkpointとdifficultyのlogをtensorboardで見るために有効化しました。
rewardのlogはleaner側で見れるのでactor側は削除しました。

checkpoint rewardの修正
1 episodeごとにrewardを線形に減少させる修正を行いました。
新たにflagを追加しており、そこでcheckpointを0にするために費やすepisode数を指定するようにしています。
defaultでは160000(480M stepsでcheckpointが0になる)を指定しています。